### PR TITLE
Enforce VFR speed limit under Class B shelves

### DIFF
--- a/pkg/aviation/db.go
+++ b/pkg/aviation/db.go
@@ -1249,6 +1249,20 @@ func InCharlieAirspace(p math.Point2LL, alt int) bool {
 	return inAirspace(DB.CharlieAirspace, p, alt)
 }
 
+// UnderBravoShelf returns true if the given position is laterally within a
+// Bravo airspace volume but below its floor altitude. This is used to enforce
+// the 200kt speed limit below Class B shelves for VFR aircraft.
+func UnderBravoShelf(p math.Point2LL, alt int) bool {
+	for _, vols := range DB.BravoAirspace {
+		for _, vol := range vols {
+			if alt < vol.Floor && vol.Inside(p, vol.Floor+1) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func InDeltaAirspace(p math.Point2LL, alt int) bool {
 	return inAirspace(DB.DeltaAirspace, p, alt)
 }

--- a/pkg/aviation/nav.go
+++ b/pkg/aviation/nav.go
@@ -491,7 +491,7 @@ func (nav *Nav) Summary(fp FlightPlan, lg *log.Logger) string {
 
 	// Speed; don't be as exhaustive as we are for altitude
 	targetAltitude, _ := nav.TargetAltitude(lg)
-	ias, _ := nav.TargetSpeed(targetAltitude, lg)
+	ias, _ := nav.TargetSpeed(targetAltitude, &fp, lg)
 	if nav.Speed.MaintainSlowestPractical {
 		lines = append(lines, fmt.Sprintf("Maintain slowest practical speed: %.0f kts", ias))
 	} else if nav.Speed.MaintainMaximumForward {
@@ -645,11 +645,11 @@ func (nav *Nav) ContactMessage(reportingPoints []ReportingPoint, star string) st
 ///////////////////////////////////////////////////////////////////////////
 // Simulation
 
-func (nav *Nav) updateAirspeed(alt float32, lg *log.Logger) (float32, bool) {
+func (nav *Nav) updateAirspeed(alt float32, fp *FlightPlan, lg *log.Logger) (float32, bool) {
 	// Figure out what speed we're supposed to be going. The following is
 	// prioritized, so once targetSpeed has been set, nothing should
 	// override it.
-	targetSpeed, targetRate := nav.TargetSpeed(alt, lg)
+	targetSpeed, targetRate := nav.TargetSpeed(alt, fp, lg)
 
 	// Stay within the aircraft's capabilities
 	targetSpeed = math.Clamp(targetSpeed, nav.Perf.Speed.Min, MaxIAS)
@@ -907,7 +907,7 @@ func (nav *Nav) Check(lg *log.Logger) {
 // returns passed waypoint if any
 func (nav *Nav) Update(wind WindModel, fp *FlightPlan, lg *log.Logger) *Waypoint {
 	targetAltitude, altitudeRate := nav.TargetAltitude(lg)
-	deltaKts, slowingTo250 := nav.updateAirspeed(targetAltitude, lg)
+	deltaKts, slowingTo250 := nav.updateAirspeed(targetAltitude, fp, lg)
 	nav.updateAltitude(targetAltitude, altitudeRate, lg, deltaKts, slowingTo250)
 	nav.updateHeading(wind, lg)
 	nav.updatePositionAndGS(wind, lg)
@@ -1401,7 +1401,7 @@ func (nav *Nav) getWaypointAltitudeConstraint() *WaypointCrossingConstraint {
 	}
 }
 
-func (nav *Nav) TargetSpeed(targetAltitude float32, lg *log.Logger) (float32, float32) {
+func (nav *Nav) TargetSpeed(targetAltitude float32, fp *FlightPlan, lg *log.Logger) (float32, float32) {
 	if nav.Airwork != nil {
 		if spd, rate, ok := nav.Airwork.TargetSpeed(); ok {
 			return spd, rate
@@ -1555,6 +1555,10 @@ func (nav *Nav) TargetSpeed(targetAltitude float32, lg *log.Logger) (float32, fl
 	// Nothing assigned by the controller or the route, so set a target
 	// based on the aircraft's altitude.
 	ias, rate := nav.targetAltitudeIAS()
+	if fp != nil && fp.Rules == FlightRulesVFR &&
+		UnderBravoShelf(nav.FlightState.Position, int(nav.FlightState.Altitude)) {
+		ias = math.Min(ias, 200)
+	}
 	//lg.Debugf("speed: %.0f based on altitude", ias)
 	return ias, rate
 }


### PR DESCRIPTION
## Summary
- implement `UnderBravoShelf` helper to detect if an aircraft is below Class B airspace
- pass flight plans into `TargetSpeed` and `updateAirspeed`
- clamp VFR speed to 200kts when operating below a Class B shelf
